### PR TITLE
Missing language variable

### DIFF
--- a/language/en/info_acp_wwh.php
+++ b/language/en/info_acp_wwh.php
@@ -75,4 +75,5 @@ $lang = array_merge($lang, array(
 	'WWH_VERSION_EXP'			=> 'Displaying users of today, or of the period set in the next option.',
 	'WWH_VERSION1'				=> 'Today',
 	'WWH_VERSION2'				=> 'Period of time',
+	'WWH_INSTALLED' 			=> 'Installed version : %s',
 ));

--- a/language/fr/info_acp_wwh.php
+++ b/language/fr/info_acp_wwh.php
@@ -76,4 +76,5 @@ $lang = array_merge($lang, array(
 	'WWH_VERSION_EXP'			=> 'Afficher les utilisateurs du jour (à partir de minuit et selon le fuseau horaire du forum) ou suivant la période de temps définie dans l’option ci-dessous.',
 	'WWH_VERSION1'				=> 'Aujourd’hui',
 	'WWH_VERSION2'				=> 'Période de temps',
+	'WWH_INSTALLED' 			=> 'Version installée : %s',
 ));


### PR DESCRIPTION
The "**WWH_INSTALLED**" language variable was missing (due to this [commit](https://github.com/bb3mobi/who-was-here/pull/10/commits/c7bdce66d7a06bcb5902831fa98d397ca9e0260f#diff-35ec0aa490424f97360405e692f3900fL44), line #44).
In my case, it was causing a freaking error in the ACP, as if aliens wanted to communicate with us :

![acp error](https://cloud.githubusercontent.com/assets/4323797/13847646/6997afd2-ec4e-11e5-8497-90d5b3e8aa8d.png)

Here is the part that was missing : 

![missing-part](https://cloud.githubusercontent.com/assets/4323797/13847725/cd03e658-ec4e-11e5-8560-6c8bc336412f.png)

So, i added the EN and FR strings, but we'll need a translation for the others languages.
